### PR TITLE
Added basic support for webpack aliases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Quickly jump to a module file from its import path or variable. Also supports ju
     - you may need to configure `hyperclick` to use an appropriate hotkey
 - `babel-plugin-module-resolver` support:
     - loads path overrides from project's `.babelrc`
+- **NEW:** very basic Webpack Module Alias support
+    - this *only* supports the `resolve.alias` section of the `webpack.config.js`
+    - **NOTE:** any modification to `webpack.config.js` requires reloading Atom for now
 - Multiple project root folders
 - Configurable settings:
     - Project-specific settings via `.jump-to-import` file
@@ -55,7 +58,7 @@ Quickly jump to a module file from its import path or variable. Also supports ju
 
 ## Usage
 
-#### Without `hyperclick`
+### Without `hyperclick`
 Press <kbd>CTRL+ALT+E</kbd> with the cursor either on:
 - an ES6 `import`/`require` path
 - the imported namespace/variable
@@ -64,7 +67,7 @@ Press <kbd>CTRL+ALT+E</kbd> with the cursor either on:
 
 to open that file and jump to the relevant method, if applicable.
 
-#### With `hyperclick`
+### With `hyperclick`
 Hold your `hyperclick` toggle key and click on any applicable string to jump to that module.
 
 ## Setup
@@ -73,11 +76,11 @@ The package looks for configuration options and path aliases in two places:
 - `.jump-to-import` files (project settings)
 - `.babelrc` files (babel aliases)
 
-#### Package Settings
+### Package Settings
 These are simply accessed in Atom's `Settings > Packages > Jump To Import`. These are basically global settings that will apply to any project.
 
 
-##### Aliases
+#### Aliases
 You can define your own path aliases in Settings.
 
 Default aliases are:
@@ -90,16 +93,16 @@ With the above default settings (for Ember projects) we would get the following 
 
 `PROJECT_NAME` in the path needs to match the project name defined in your `package.json` file in the root directory.
 
-##### Project Name
+#### Project Name
 The package will look for a `package.json` file in every root directory of the project to determine project names.
 
-##### File Extensions
+#### File Extensions
 You can also define a list of file extensions to look for.
 
-##### Ember.Service Aliases
+#### Ember.Service Aliases
 You can define `Ember.Service` name aliases, in case the injected variable name and registered service name differ.
 
-#### .jump-to-import
+### .jump-to-import
 Optionally, you can add a `.jump-to-import` file in any root folder of your project which will take precedence over the package settings. These allow for project-specific settings and aliases.
 
 You can trigger the `jump-to-import:create-project-config` through the `Command Palette` to generate a default config.
@@ -132,7 +135,7 @@ Here's a sample config, using default settings:
 }
 ```
 
-#### .babelrc
+### .babelrc
 Optionally, you can use path aliases defined in `.babelrc`. A sample file looks like:
 
 ```javascript
@@ -150,7 +153,7 @@ Optionally, you can use path aliases defined in `.babelrc`. A sample file looks 
 
 With the above `.babelrc` file, a path of `utils/test` will resolve to `./src/utils/test.js`
 
-#### Settings & Aliases Priority
+### Settings & Aliases Priority
 Project settings and aliases defined in `.jump-to-import` will always take priority. Next, `.babelrc` aliases take precedence over aliases defined in Package Settings.
 
 Remember, `.jump-to-import` > `.babelrc` > `Package Settings`

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -85,6 +85,14 @@ module.exports = DefaultConfig = {
     order: 70
   },
 
+  disableWebpack: {
+    title: 'Disable Webpack aliases',
+    description: 'Disable path aliases from webpack.config.js',
+    type: 'boolean',
+    default: false,
+    order: 75
+  },
+
   disableHyperclickSupport: {
     description:
       'Disable hyperclick support (which makes variables and paths clickable). Requires Atom Reload/Restart for changes to take effect.',

--- a/lib/jump-to-import.js
+++ b/lib/jump-to-import.js
@@ -151,10 +151,25 @@ class JumpToImport {
     const projectSettings = Config.loadProjectSettings(projectConfigUrls);
     const configKeys = Object.keys(this.config);
     const userSettings = Config.loadUserSettings(configKeys);
-    const babelConfigs = AtomUtils.getBabelRc(projectPaths);
     const options = Object.assign({}, userSettings, projectSettings);
+    let babelConfigs = null;
+    let webpackConfigs = null;
+
+    if (!options.user.disableBabelRc) {
+      babelConfigs = AtomUtils.getBabelRc(projectPaths);
+    }
+
+    if (!options.user.disableWebpack) {
+      webpackConfigs = AtomUtils.getWebpackConfigs(projectPaths);
+    }
+
     const userOverrides = options.user.pathOverrides;
-    const aliases = Utils.extractAllAliases(userOverrides, babelConfigs, projectConfigUrls);
+    const aliases = Utils.extractAllAliases(
+      userOverrides,
+      babelConfigs,
+      projectConfigUrls,
+      webpackConfigs
+    );
 
     if (userSettings.user.enableDebug) {
       Logger.enable();
@@ -171,7 +186,7 @@ class JumpToImport {
       aliases
     });
 
-    this.subscribeToChanges(configKeys, projectConfigUrls, babelConfigs);
+    this.subscribeToChanges(configKeys, projectConfigUrls, babelConfigs, webpackConfigs);
   }
 
   /**
@@ -181,17 +196,22 @@ class JumpToImport {
    * @param {Object} projectConfigUrls Hash of .jump-to-import paths
    * @param {Object} babelConfigs Hash of .babelrc paths
    */
-  subscribeToChanges(configKeys, projectConfigUrls, babelConfigs) {
+  subscribeToChanges(configKeys, projectConfigUrls, babelConfigs, webpackConfigs) {
     if (!this.isSubscribedToChanges) {
       this.isSubscribedToChanges = true;
 
-      const callback = () => {
+      const resetInitialization = () => {
         this.initialized = false;
       };
 
-      Utils.subscribeToConfigChanges(this.subscriptions, configKeys, callback);
-      Utils.subscribeToProjectConfigChanges(projectConfigUrls, callback);
-      Utils.subscribeToBabelChanges(babelConfigs, callback);
+      Utils.subscribeToConfigChanges(this.subscriptions, configKeys, resetInitialization);
+      Utils.subscribeToProjectConfigChanges(projectConfigUrls, resetInitialization);
+
+      if (!this.options.disableBabelRc) {
+        Utils.subscribeToBabelChanges(babelConfigs, resetInitialization);
+      }
+      // TODO: re-enable once require.cache is fixed
+      // Utils.subscribeToWebpackChanges(webpackConfigs, resetInitialization);
     }
   }
 
@@ -202,7 +222,6 @@ class JumpToImport {
   createDefaultProjectConfig() {
     const configKeys = Object.keys(this.config);
     const userSettings = Config.loadUserSettings(configKeys).user;
-
     Config.createDefaultProjectConfig(AtomUtils.getProjectPaths(), userSettings);
   }
 

--- a/lib/utils/atom.js
+++ b/lib/utils/atom.js
@@ -183,6 +183,38 @@ module.exports = {
   },
 
   /**
+   * Gets all webpack.config.js files from each root directory in the project
+   * @method getWebpackConfigs
+   * @param  {Array} rootPaths List of root project directories
+   * @return {Object} Hash of webpack.config.js files
+   */
+  getWebpackConfigs(rootPaths) {
+    let json = {};
+
+    rootPaths.forEach(path => {
+      const filePath = npmPath.join(path, 'webpack.config.js');
+      let webpack = null;
+
+      if (fs.existsSync(filePath)) {
+        try {
+          // TODO: fix -- deleting cache has no effect to force file reload
+          if (require.cache[filePath]) {
+            delete require.cache[require.resolve(filePath)];
+          }
+
+          webpack = require(filePath);
+        } catch (err) {
+          webpack = {};
+        }
+
+        json[path] = webpack.resolve.alias;
+      }
+    });
+
+    return json;
+  },
+
+  /**
    * Get all directories in project
    * @method getDirectories
    * @return {Array} List of project directories
@@ -264,7 +296,12 @@ module.exports = {
    * @return {String} String under user's cursor
    */
   findStringUnderCursor() {
-    return this.getCursorString('.string') || this.getEditor().getWordUnderCursor().replace(/,/g);
+    return (
+      this.getCursorString('.string') ||
+      this.getEditor()
+        .getWordUnderCursor()
+        .replace(/,/g)
+    );
   },
 
   /**
@@ -273,15 +310,21 @@ module.exports = {
    * @return {String} String under user's cursor
    */
   findHTMLBarsStringUnderCursor() {
-    let cursorString = this.getCursorString('.htmlbars') || this.getCursorString('.handlebars')
+    let cursorString = this.getCursorString('.htmlbars') || this.getCursorString('.handlebars');
 
-    cursorString = cursorString.replace('{{', '')
+    cursorString = cursorString
+      .replace('{{', '')
       .replace('#', '')
       .replace('}}', '')
       .trim()
       .split(' ')[0];
 
-    return cursorString || this.getEditor().getWordUnderCursor().replace(/,/g);
+    return (
+      cursorString ||
+      this.getEditor()
+        .getWordUnderCursor()
+        .replace(/,/g)
+    );
   },
 
   /**
@@ -609,7 +652,10 @@ module.exports = {
     };
 
     const methodName = `find${_capitalize(positionMap[position])}mostSibling`;
-    return atom.workspace.getCenter().getActivePane()[methodName]();
+    return atom.workspace
+      .getCenter()
+      .getActivePane()
+      [methodName]();
   },
 
   /**

--- a/lib/utils/general.js
+++ b/lib/utils/general.js
@@ -44,6 +44,25 @@ const _parseBabelConfig = (path, babelrc) => {
 };
 
 /**
+ * Parses webpack config file to find module aliases
+ * @method   _parseWebpackConfig
+ * @param    {String} rootPath Project root path
+ * @param    {Object} webpack Webpack config
+ * @return   {Object} Webpack aliases
+ */
+const _parseWebpackConfig = (rootPath, webpack) => {
+  const aliases = {
+    [rootPath]: {}
+  };
+
+  Object.keys(webpack).forEach(alias => {
+    aliases[rootPath][alias] = webpack[alias];
+  });
+
+  return aliases;
+};
+
+/**
  * Extracts path aliases from .babelrc if valid plugin names were found
  * @method _extractBabelAliases
  * @param  {Array} plugin List of plugin configuration options
@@ -117,13 +136,14 @@ module.exports = {
    * @param  {Object} projectConfigUrls Hash of .jump-to-import paths
    * @return {Object} Hash of path aliases
    */
-  extractAllAliases(userOverrides, babelConfigs, projectConfigUrls) {
+  extractAllAliases(userOverrides, babelConfigs, projectConfigUrls, webpackConfigs) {
     const projectPaths = AtomUtils.getProjectPaths();
     const projectNames = this.extractProjectNames(AtomUtils.getPackageJson());
     const babelAliases = this.extractBabelAliases(babelConfigs);
     const allAliases = [];
     const userAliases = this.extractUserAliases(userOverrides, projectNames);
     const projectAliases = this.extractProjectAliases(projectConfigUrls, projectNames);
+    const webpackAliases = this.extractWebpackAliases(webpackConfigs);
 
     let aliases = {};
 
@@ -139,9 +159,33 @@ module.exports = {
       allAliases.push(projectAliases);
     }
 
+    if (webpackAliases) {
+      allAliases.push(webpackAliases);
+    }
+
     if (allAliases.length) {
       aliases = deepmerge.all(allAliases);
     }
+
+    return aliases;
+  },
+
+  /**
+   * Extracts webpack module aliases
+   * @method   extractWebpackAliases
+   * @param    {Object} configs Webpack configs, keyed by project root path
+   * @return   {Object} Webpack aliases
+   */
+  extractWebpackAliases(configs) {
+    if (!configs) {
+      return null;
+    }
+
+    let aliases = {};
+
+    Object.keys(configs).forEach(path => {
+      aliases = _parseWebpackConfig(path, configs[path]);
+    });
 
     return aliases;
   },
@@ -193,6 +237,10 @@ module.exports = {
    * @return {Object} Hash of path aliases
    */
   extractBabelAliases(configs) {
+    if (!configs) {
+      return null;
+    }
+
     let aliases = {};
 
     Object.keys(configs).forEach(path => {
@@ -272,6 +320,19 @@ module.exports = {
       if (configKeys && configKeys.length) {
         configKeys.forEach(projectRoot => {
           const fileName = configs[projectRoot].file;
+          this.subscribeToFileChanges(fileName, callback);
+        });
+      }
+    }
+  },
+
+  subscribeToWebpackChanges(configs, callback) {
+    if (configs) {
+      const configKeys = Object.keys(configs);
+
+      if (configKeys && configKeys.length) {
+        configKeys.forEach(projectRoot => {
+          const fileName = npmPath.join(projectRoot, 'webpack.config.js');
           this.subscribeToFileChanges(fileName, callback);
         });
       }


### PR DESCRIPTION
This doesn't support the entire Webpack Module API, just the `resolve.alias` section.
https://github.com/alexheyd/atom-jump-to-import/issues/26