### PR TITLE
Only take into account fileExtensions

### DIFF
--- a/lib/utils/filepath.js
+++ b/lib/utils/filepath.js
@@ -292,9 +292,13 @@ module.exports = {
       if (!isExternalModule && mod.path.indexOf(rootPath) === -1) {
         mod.path = npmPath.join(rootPath, mod.path);
       }
-
-      const hasExtension = !!npmPath.extname(mod.path);
-
+      
+      const ext = npmPath.extname(mod.path);
+      let hasExtension = false;
+      for (let fileExtension of fileExtensions) {
+        if ('.'+fileExtension === ext) hasExtension = true;
+      }
+      
       if (!hasExtension) {
         mod.path = this.appendFileExtension(mod.path, fileExtensions);
       }


### PR DESCRIPTION
This solves the case where the filename has a period in it. hasExtensions will now only be true if it is one of the fileExtensions (default .js or .jsx).